### PR TITLE
Fixed bug in ArrayOfArraysView move constructor.

### DIFF
--- a/src/ArrayOfArrays.hpp
+++ b/src/ArrayOfArrays.hpp
@@ -103,7 +103,7 @@ public:
   /**
    * @brief Conversion operator to ArrayOfArraysView<T, INDEX_TYPE const>.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator ArrayOfArraysView< T, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return reinterpret_cast< ArrayOfArraysView< T, INDEX_TYPE const > const & >(*this); }
@@ -112,7 +112,7 @@ public:
    * @brief Method to convert to ArrayOfArraysView<T, INDEX_TYPE const>. Use this method when
    *        the above UDC isn't invoked, this usually occurs with template argument deduction.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   ArrayOfArraysView< T, INDEX_TYPE const > const & toView() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
@@ -121,7 +121,7 @@ public:
    *        Although ArrayOfArraysView defines this operator nvcc won't let us alias it so
    *        it is redefined here.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator ArrayOfArraysView< T, INDEX_TYPE const, true > const &
   () const LVARRAY_RESTRICT_THIS
   { return toViewSemiConst(); }
@@ -131,7 +131,7 @@ public:
    *        Although ArrayOfArraysView defines this operator nvcc won't let us alias it so
    *        it is redefined here.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator ArrayOfArraysView< T const, INDEX_TYPE const, true > const &
   () const LVARRAY_RESTRICT_THIS
   { return toViewConst(); }

--- a/src/ArrayOfSets.hpp
+++ b/src/ArrayOfSets.hpp
@@ -109,7 +109,7 @@ public:
   /**
    * @brief Conversion operator to an ArrayOfArraysView.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator ArrayOfSetsView< T, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return reinterpret_cast< ArrayOfSetsView< T, INDEX_TYPE const > const & >(*this); }
@@ -124,7 +124,7 @@ public:
   /**
    * @brief Method to convert to an immutable ArrayOfSetsView.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator ArrayOfSetsView< T const, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return toViewConst(); }
@@ -133,7 +133,7 @@ public:
    * @brief Conversion operator to an immutable ArrayOfArraysView.
    */
   template< class U=T >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator ArrayOfArraysView< T const, INDEX_TYPE const, true >
   () const LVARRAY_RESTRICT_THIS
   { return toArrayOfArraysView(); }

--- a/src/ArrayOfSetsView.hpp
+++ b/src/ArrayOfSetsView.hpp
@@ -77,7 +77,7 @@ public:
    * @brief User defined conversion to move from T to T const.
    */
   template< class U=T >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator typename std::enable_if< !std::is_const< U >::value,
                                     ArrayOfSetsView< T const, INDEX_TYPE const > const & >::type
     () const LVARRAY_RESTRICT_THIS
@@ -87,14 +87,14 @@ public:
    * @brief Method to convert T to T const. Use this method when the above UDC
    *        isn't invoked, this usually occurs with template argument deduction.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfSetsView< T const, INDEX_TYPE const > const & toViewConst() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
   /**
    * @brief Method to convert to an immutable ArrayOfArraysView.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfArraysView< T const, INDEX_TYPE const, true > const & toArrayOfArraysView() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
@@ -117,7 +117,7 @@ public:
    * @brief Return an object provides an iterable interface to the given set.
    * @param [in] i the set to get an iterator for.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   typename ParentClass::IterableArray getIterableSet( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::getIterableArray( i ); }
 
@@ -125,7 +125,7 @@ public:
    * @brief Return the size of the given set.
    * @param [in] i the set to querry.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE_NC sizeOfSet( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::sizeOfArray( i ); }
 
@@ -133,7 +133,7 @@ public:
    * @brief Return the capacity of the given set.
    * @param [in] i the set to querry.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE_NC capacityOfSet( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::capacityOfArray( i ); }
 
@@ -141,7 +141,7 @@ public:
    * @brief Return an ArraySlice1d<T const> (pointer to const) to the values of the given array.
    * @param [in] i the array to access.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   ArraySlice< T const, 1, 0, INDEX_TYPE_NC > operator[]( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::operator[]( i ); }
 
@@ -150,7 +150,7 @@ public:
    * @param [in] i the array to access.
    * @param [in] j the index within the array to access.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   T const & operator()( INDEX_TYPE const i, INDEX_TYPE const j ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::operator()( i, j ); }
 
@@ -290,7 +290,7 @@ protected:
    * @param [in] i the array to access.
    * @note This method is protected because it returns a non-const pointer.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   ArraySlice< T, 1, 0, INDEX_TYPE_NC > getSetValues( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::operator[]( i ); }
 

--- a/src/ArraySlice.hpp
+++ b/src/ArraySlice.hpp
@@ -128,30 +128,26 @@ public:
    * @brief Return a new immutable slice.
    */
   template< typename U=T >
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   ArraySlice< T const, NDIM, USD, INDEX_TYPE >
   toSliceConst() const LVARRAY_RESTRICT_THIS noexcept
-  {
-    return ArraySlice< T const, NDIM, USD, INDEX_TYPE >( m_data, m_dims, m_strides );
-  }
+  { return ArraySlice< T const, NDIM, USD, INDEX_TYPE >( m_data, m_dims, m_strides ); }
 
   /**
    * @brief User defined conversion to return a new immutable slice.
    */
   template< typename U=T >
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   operator std::enable_if_t< !std::is_const< U >::value,
                              ArraySlice< T const, NDIM, USD, INDEX_TYPE > >
     () const LVARRAY_RESTRICT_THIS noexcept
-  {
-    return toSliceConst();
-  }
+  { return toSliceConst(); }
 
   /**
    * @brief User defined conversion to convert an ArraySlice<T,1,0> to a raw pointer.
    */
   template< int _NDIM=NDIM, int _USD=USD >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator std::enable_if_t< _NDIM == 1 && _USD == 0, T * const LVARRAY_RESTRICT >
     () const noexcept LVARRAY_RESTRICT_THIS
   { return m_data; }
@@ -193,7 +189,7 @@ public:
    * @note This is a standard fortran like parentheses interface to array access.
    */
   template< typename ... INDICES >
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   T & operator()( INDICES... indices ) const
   {
     static_assert( sizeof ... (INDICES) == NDIM, "number of indices does not match NDIM" );
@@ -219,7 +215,7 @@ public:
   /**
    * @brief Return the allocated size.
    */
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   INDEX_TYPE size() const noexcept
   { return multiplyAll< NDIM >( m_dims ); }
 
@@ -240,11 +236,9 @@ public:
    * @brief Return true iff the given pointer matches the data pointer of this ArraySlice.
    * @param ptr the pointer to check.
    */
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   bool operator==( T const * const ptr ) const
-  {
-    return m_data == ptr;
-  }
+  { return m_data == ptr; }
 
   /**
    * @brief Check if the slice is contiguous in memory
@@ -252,7 +246,7 @@ public:
    * @return @p true if represented slice is contiguous in memory
    */
   template< int _USD = USD >
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   std::enable_if_t< ( _USD >= 0), bool >
   isContiguous() const
   {
@@ -277,12 +271,10 @@ public:
    *         have already lost its unit stride dimension
    */
   template< int USD_ = USD >
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   std::enable_if_t< (USD_ < 0), bool >
   isContiguous() const
-  {
-    return false;
-  }
+  { return false; }
 
   /**
    * @brief Return a pointer to the values.

--- a/src/ArrayView.hpp
+++ b/src/ArrayView.hpp
@@ -107,7 +107,7 @@ public:
    * lambda which is used to execute a cuda kernel, the data will be allocated and copied
    * to the device (if it doesn't already exist).
    */
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   ArrayView( ArrayView const & source ) noexcept:
     m_dims{ 0 },
     m_strides{ 0 },
@@ -126,7 +126,7 @@ public:
    * @param source object to move
    * @return *this
    */
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   ArrayView( ArrayView && source ):
     m_dims{ 0 },
     m_strides{ 0 },
@@ -148,7 +148,7 @@ public:
    * @param rhs object to copy.
    * @return *this
    */
-  inline CONSTEXPRFUNC
+  inline constexpr
   ArrayView & operator=( ArrayView const & rhs ) noexcept
   {
     m_dataBuffer = rhs.m_dataBuffer;
@@ -167,7 +167,7 @@ public:
    * @param rhs object to copy.
    * @return *this
    */
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   ArrayView & operator=( ArrayView && rhs )
   {
     m_dataBuffer = std::move( rhs.m_dataBuffer );
@@ -188,7 +188,7 @@ public:
    */
   DISABLE_HD_WARNING
   template< typename U = T >
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   std::enable_if_t< !(std::is_const< U >::value), ArrayView const & >
   operator=( T const & rhs ) const noexcept
   {
@@ -206,12 +206,10 @@ public:
    *        In addition the data held by the innermost array will be const.
    */
   template< typename U = T >
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   std::enable_if_t< !std::is_const< U >::value, ViewTypeConst & >
   toViewConst() const
-  {
-    return reinterpret_cast< ViewTypeConst & >( *this );
-  }
+  { return reinterpret_cast< ViewTypeConst & >( *this ); }
 
   /**
    * @brief User Defined Conversion operator to move from an ArrayView<T> const to
@@ -221,7 +219,7 @@ public:
    *       const specifier on the template parameter T.
    */
   template< typename U = T >
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   operator std::enable_if_t< !std::is_const< U >::value,
                              ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > const & >
     () const noexcept
@@ -232,55 +230,45 @@ public:
   /**
    * @brief Return an ArraySlice representing this ArrayView.
    */
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   ArraySlice< T, NDIM, USD, INDEX_TYPE >
   toSlice() const noexcept
-  {
-    return ArraySlice< T, NDIM, USD, INDEX_TYPE >( data(), m_dims, m_strides );
-  }
+  { return ArraySlice< T, NDIM, USD, INDEX_TYPE >( data(), m_dims, m_strides ); }
 
   /**
    * @brief Return an immutable ArraySlice representing this ArrayView.
    */
   template< typename U=T >
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   ArraySlice< T const, NDIM, USD, INDEX_TYPE >
   toSliceConst() const noexcept
-  {
-    return ArraySlice< T const, NDIM, USD, INDEX_TYPE >( data(), m_dims, m_strides );
-  }
+  { return ArraySlice< T const, NDIM, USD, INDEX_TYPE >( data(), m_dims, m_strides ); }
 
   /**
    * @brief User defined conversion to an ArraySlice representing this ArrayView.
    */
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   operator ArraySlice< T, NDIM, USD, INDEX_TYPE >() const noexcept
-  {
-    return toSlice();
-  }
+  { return toSlice(); }
 
   /**
    * @brief User defined conversion to an immutable ArraySlice representing this ArrayView.
    */
   template< typename U=T >
-  inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
+  inline LVARRAY_HOST_DEVICE constexpr
   operator std::enable_if_t< !std::is_const< U >::value,
                              ArraySlice< T const, NDIM, USD, INDEX_TYPE > const >
     () const noexcept
-  {
-    return toSliceConst();
-  }
+  { return toSliceConst(); }
 
   /**
    * @brief User defined conversion to convert a ArraySlice< T, 1, 0 > to a raw pointer.
    */
   template< int _NDIM=NDIM, int _USD=USD >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator std::enable_if_t< _NDIM == 1 && _USD == 0, T * const LVARRAY_RESTRICT >
     () const noexcept LVARRAY_RESTRICT_THIS
-  {
-    return data();
-  }
+  { return data(); }
 
   /**
    * @brief Return the allocated size.
@@ -311,14 +299,14 @@ public:
   /**
    * @brief Return a pointer to the begining of the data.
    */
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   T * begin() const
   { return data(); }
 
   /**
    * @brief Return a pointer to the end of the data (one past the last value).
    */
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   T * end() const
   { return data() + size(); }
 

--- a/src/CRSMatrix.hpp
+++ b/src/CRSMatrix.hpp
@@ -104,7 +104,7 @@ public:
   /**
    * @brief Conversion operator to CRSMatrixView<T, COL_TYPE, INDEX_TYPE const>.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator CRSMatrixView< T, COL_TYPE, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return reinterpret_cast< CRSMatrixView< T, COL_TYPE, INDEX_TYPE const > const & >(*this); }
@@ -113,7 +113,7 @@ public:
    * @brief Method to convert to CRSMatrixView<T, COL_TYPE, INDEX_TYPE const>. Use this method when
    *        the above UDC isn't invoked, this usually occurs with template argument deduction.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   CRSMatrixView< T, COL_TYPE, INDEX_TYPE const > const & toView() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
@@ -122,7 +122,7 @@ public:
    *        Although CRSMatrixView defines this operator nvcc won't let us alias it so
    *        it is redefined here.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator CRSMatrixView< T, COL_TYPE const, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return toViewSemiConst(); }
@@ -132,7 +132,7 @@ public:
    *        Although CRSMatrixView defines this operator nvcc won't let us alias it so
    *        it is redefined here.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return toViewConst(); }
@@ -142,7 +142,7 @@ public:
    *        Although CRSMatrixView defines this operator nvcc won't let us alias it so
    *        it is redefined here.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator SparsityPatternView< COL_TYPE const, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return toSparsityPatternView(); }

--- a/src/CRSMatrixView.hpp
+++ b/src/CRSMatrixView.hpp
@@ -31,23 +31,20 @@ namespace LvArray
 {
 
 // Wrapper around RAJA::atomicAdd that allows for non primitive types with RAJA::seq_atomic
-// TODO: Can be removed after updating RAJA.
 namespace
 {
+
 template< typename POLICY, typename T >
 LVARRAY_HOST_DEVICE inline
 void atomicAdd( POLICY, T * const acc, T const & val )
-{
-  RAJA::atomicAdd< POLICY >( acc, val );
-}
+{ RAJA::atomicAdd< POLICY >( acc, val ); }
 
 DISABLE_HD_WARNING
 template< typename T >
-LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+LVARRAY_HOST_DEVICE constexpr inline
 void atomicAdd( RAJA::seq_atomic, T * acc, T const & val )
-{
-  *acc += val;
-}
+{ *acc += val; }
+
 }
 
 /**
@@ -106,7 +103,7 @@ public:
    *        This prevents you from inserting or removing but still allows modification of the matrix entries.
    */
   template< class U=T, class CTYPE=COL_TYPE >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator typename std::enable_if< !std::is_const< U >::value && !std::is_const< CTYPE >::value,
                                     CRSMatrixView< T, COL_TYPE const, INDEX_TYPE const > const & >::type
     () const LVARRAY_RESTRICT_THIS
@@ -116,7 +113,7 @@ public:
    * @brief Method to convert to CRSMatrixView<T, COL_TYPE const, INDEX_TYPE const>. Use this method
    *        when the above UDC isn't invoked, this usually occurs with template argument deduction.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   CRSMatrixView< T, COL_TYPE const, INDEX_TYPE const > const & toViewSemiConst() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
@@ -125,7 +122,7 @@ public:
    *        This prevents you from inserting, removing or modifying the matrix entries.
    */
   template< class U=T >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator typename std::enable_if< !std::is_const< U >::value, CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const > const & >::type
     () const LVARRAY_RESTRICT_THIS
   { return reinterpret_cast< CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const > const & >(*this); }
@@ -134,14 +131,14 @@ public:
    * @brief Method to convert to CRSMatrixView<T const, COL_TYPE const, INDEX_TYPE const>. Use this method
    *        when the above UDC isn't invoked, this usually occurs with template argument deduction.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const > const & toViewConst() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
   /**
    * @brief Method to convert to SparsityPatternView<COL_TYPE const, INDEX_TYPE const>.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   SparsityPatternView< COL_TYPE const, INDEX_TYPE const > const & toSparsityPatternView() const
   { return reinterpret_cast< SparsityPatternView< COL_TYPE const, INDEX_TYPE const > const & >(*this); }
 

--- a/src/MallocBuffer.hpp
+++ b/src/MallocBuffer.hpp
@@ -138,18 +138,14 @@ public:
   /**
    * @brief Return a pointer to the beginning of the buffer.
    */
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   T * data() const
-  {
-    return m_data;
-  }
+  { return m_data; }
 
   template< typename INDEX_TYPE >
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   T & operator[]( INDEX_TYPE const i ) const
-  {
-    return m_data[ i ];
-  }
+  { return m_data[ i ]; }
 
 private:
   T * LVARRAY_RESTRICT m_data = nullptr;

--- a/src/SortedArray.hpp
+++ b/src/SortedArray.hpp
@@ -64,12 +64,12 @@ public:
   // Duplicating these next two methods because SFINAE macros don't seem to pick them up otherwise.
 
   // using SortedArrayView<T, INDEX_TYPE>::empty;
-  CONSTEXPRFUNC inline
+  constexpr inline
   bool empty() const
   { return SortedArrayView< T, INDEX_TYPE >::empty(); }
 
   // using SortedArrayView<T, INDEX_TYPE>::size;
-  CONSTEXPRFUNC inline
+  constexpr inline
   INDEX_TYPE size() const
   { return SortedArrayView< T, INDEX_TYPE >::size(); }
 
@@ -138,7 +138,7 @@ public:
    * @brief User defined conversion to SortedArrayView<T const> const.
    */
   template< typename U = T >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator ViewType const & () const LVARRAY_RESTRICT_THIS
   { return reinterpret_cast< ViewType const & >( *this ); }
 

--- a/src/SortedArrayView.hpp
+++ b/src/SortedArrayView.hpp
@@ -29,9 +29,6 @@
 
 #ifdef USE_ARRAY_BOUNDS_CHECK
 
-#undef CONSTEXPRFUNC
-#define CONSTEXPRFUNC
-
 #define SORTEDARRAY_CHECK_BOUNDS( index ) \
   LVARRAY_ERROR_IF( index < 0 || index >= size(), \
                     "Array Bounds Check Failed: index=" << index << " size()=" << size())
@@ -105,7 +102,7 @@ public:
    * @note The pointer is of type T const * because it would be unsafe to modify
    *        the values of the set.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   T const * data() const
   { return m_values.data(); }
 
@@ -123,28 +120,28 @@ public:
   /**
    * @brief Return a pointer to the beginning of the array.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   T const * begin() const
   { return data(); }
 
   /**
    * @brief Return a pointer to the end of the array.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   T const * end() const
   { return data() + size(); }
 
   /**
    * @brief Return true if the array holds no values.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   bool empty() const
   { return size() == 0; }
 
   /**
    * @brief Return the number of values in the array.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE size() const
   { return m_size; }
 

--- a/src/SparsityPattern.hpp
+++ b/src/SparsityPattern.hpp
@@ -98,7 +98,7 @@ public:
   /**
    * @brief Conversion operator to SparsityPatternView<COL_TYPE, INDEX_TYPE const>.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator SparsityPatternView< COL_TYPE, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return reinterpret_cast< SparsityPatternView< COL_TYPE, INDEX_TYPE const > const & >(*this); }
@@ -107,7 +107,7 @@ public:
    * @brief Method to convert to SparsityPatternView<COL_TYPE, INDEX_TYPE const>. Use this method when
    *        the above UDC isn't invoked, this usually occurs with template argument deduction.
    */
-  inline
+  constexpr inline
   SparsityPatternView< COL_TYPE, INDEX_TYPE const > const & toView() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
@@ -116,7 +116,7 @@ public:
    *        Although SparsityPatternView defines this operator nvcc won't let us alias it so
    *        it is redefined here.
    */
-  CONSTEXPRFUNC inline
+  constexpr inline
   operator SparsityPatternView< COL_TYPE const, INDEX_TYPE const > const &
   () const LVARRAY_RESTRICT_THIS
   { return toViewConst(); }

--- a/src/SparsityPatternView.hpp
+++ b/src/SparsityPatternView.hpp
@@ -85,7 +85,7 @@ public:
    * @brief User defined conversion to move from COL_TYPE to COL_TYPE const.
    */
   template< class CTYPE=COL_TYPE >
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   operator typename std::enable_if< !std::is_const< CTYPE >::value,
                                     SparsityPatternView< COL_TYPE const, INDEX_TYPE const > const & >::type
     () const LVARRAY_RESTRICT_THIS
@@ -95,7 +95,7 @@ public:
    * @brief Method to convert COL_TYPE to COL_TYPE const. Use this method when the above UDC
    *        isn't invoked, this usually occurs with template argument deduction.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   SparsityPatternView< COL_TYPE const, INDEX_TYPE const > const & toViewConst() const LVARRAY_RESTRICT_THIS
   { return *this; }
 
@@ -116,14 +116,14 @@ public:
   /**
    * @brief Return the number of rows in the matrix.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE_NC numRows() const LVARRAY_RESTRICT_THIS
   { return ParentClass::size(); }
 
   /**
    * @brief Return the number of columns in the matrix.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE_NC numColumns() const LVARRAY_RESTRICT_THIS
   { return m_numCols; }
 
@@ -146,14 +146,14 @@ public:
    * @brief Return the total number of non zero entries in the given row.
    * @param [in] row the row to query.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE_NC numNonZeros( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::sizeOfSet( row ); }
 
   /**
    * @brief Return the total number of non zero entries able to be stored without a reallocation.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE_NC nonZeroCapacity() const LVARRAY_RESTRICT_THIS
   { return m_values.capacity(); }
 
@@ -162,7 +162,7 @@ public:
    *        subsequent rows and possibly reallocating.
    * @param [in] row the row to query.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE_NC nonZeroCapacity( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
   { return ParentClass::capacityOfSet( row ); }
 
@@ -177,7 +177,7 @@ public:
    * @brief Return true iff the given row is all zeros.
    * @param [in] row the row to query.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   bool empty( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
   { return numNonZeros( row ) == 0; }
 
@@ -195,7 +195,7 @@ public:
    *        This array has length numNonZeros(row).
    * @param [in] row the row to access.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   ArraySlice< COL_TYPE const, 1, 0, INDEX_TYPE_NC > getColumns( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
   { return (*this)[row]; }
 
@@ -203,7 +203,7 @@ public:
    * @brief Return a pointer to the array of offsets.
    *        This array has length numRows() + 1.
    */
-  LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+  LVARRAY_HOST_DEVICE constexpr inline
   INDEX_TYPE const * getOffsets() const LVARRAY_RESTRICT_THIS
   { return m_offsets.data(); }
 

--- a/src/StackBuffer.hpp
+++ b/src/StackBuffer.hpp
@@ -59,7 +59,7 @@ public:
   StackBuffer( bool=true )
   {}
 
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   StackBuffer( StackBuffer const & src, std::ptrdiff_t ):
     StackBuffer( src )
   {}
@@ -86,27 +86,21 @@ public:
   /**
    * @brief Return the capacity of the buffer.
    */
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   std::ptrdiff_t capacity() const
-  {
-    return LENGTH;
-  }
+  { return LENGTH; }
 
   /**
    * @brief Return a pointer to the beginning of the buffer.
    */
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   T * data() const
-  {
-    return const_cast< T * >( m_data );
-  }
+  { return const_cast< T * >( m_data ); }
 
   template< typename INDEX_TYPE >
-  LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+  LVARRAY_HOST_DEVICE inline constexpr
   T & operator[]( INDEX_TYPE const i ) const
-  {
-    return const_cast< T * >( m_data )[ i ];
-  }
+  { return const_cast< T * >( m_data )[ i ]; }
 
 private:
   T m_data[ LENGTH ];

--- a/src/arrayManipulation.hpp
+++ b/src/arrayManipulation.hpp
@@ -56,7 +56,7 @@ namespace arrayManipulation
  * @param [in] i the value to check.
  */
 template< typename INDEX_TYPE >
-LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+LVARRAY_HOST_DEVICE inline constexpr
 typename std::enable_if< std::is_signed< INDEX_TYPE >::value, bool >::type
 isPositive( INDEX_TYPE const i )
 { return i >= 0; }
@@ -66,7 +66,7 @@ isPositive( INDEX_TYPE const i )
  * @brief Returns true. This specialization for unsigned types avoids compiler warnings.
  */
 template< typename INDEX_TYPE >
-LVARRAY_HOST_DEVICE inline CONSTEXPRFUNC
+LVARRAY_HOST_DEVICE inline constexpr
 typename std::enable_if< !std::is_signed< INDEX_TYPE >::value, bool >::type
 isPositive( INDEX_TYPE const )
 { return true; }

--- a/src/sortedArrayManipulation.hpp
+++ b/src/sortedArrayManipulation.hpp
@@ -48,11 +48,11 @@ enum Description
   UNSORTED_WITH_DUPLICATES
 };
 
-LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+LVARRAY_HOST_DEVICE constexpr inline
 bool isSorted( Description const desc )
 { return desc == SORTED_UNIQUE || desc == SORTED_WITH_DUPLICATES; }
 
-LVARRAY_HOST_DEVICE CONSTEXPRFUNC inline
+LVARRAY_HOST_DEVICE constexpr inline
 bool isUnique( Description const desc )
 { return desc == SORTED_UNIQUE || desc == UNSORTED_NO_DUPLICATES; }
 
@@ -146,7 +146,8 @@ struct less
    * @brief Return true iff lhs < rhs.
    */
   DISABLE_HD_WARNING
-  CONSTEXPRFUNC LVARRAY_HOST_DEVICE inline bool operator() ( T const & lhs, T const & rhs ) const LVARRAY_RESTRICT_THIS
+  constexpr LVARRAY_HOST_DEVICE inline
+  bool operator() ( T const & lhs, T const & rhs ) const LVARRAY_RESTRICT_THIS
   { return lhs < rhs; }
 };
 
@@ -162,7 +163,8 @@ struct greater
    * @brief Return true iff lhs > rhs.
    */
   DISABLE_HD_WARNING
-  CONSTEXPRFUNC LVARRAY_HOST_DEVICE inline bool operator() ( T const & lhs, T const & rhs ) const LVARRAY_RESTRICT_THIS
+  constexpr LVARRAY_HOST_DEVICE inline
+  bool operator() ( T const & lhs, T const & rhs ) const LVARRAY_RESTRICT_THIS
   { return lhs > rhs; }
 };
 

--- a/unitTests/testArrayOfArrays.cpp
+++ b/unitTests/testArrayOfArrays.cpp
@@ -615,6 +615,7 @@ protected:
 using TestTypes = ::testing::Types< INDEX_TYPE, Tensor, TestString >;
 TYPED_TEST_CASE( ArrayOfArraysTest, TestTypes );
 
+
 TYPED_TEST( ArrayOfArraysTest, emptyConstruction )
 {
   ArrayOfArrays< TypeParam > a;
@@ -654,6 +655,7 @@ TYPED_TEST( ArrayOfArraysTest, appendArray )
   this->appendArray( 100, 10 );
 }
 
+
 TYPED_TEST( ArrayOfArraysTest, appendArray2 )
 {
   this->appendArray2( 100, 10 );
@@ -665,6 +667,50 @@ TYPED_TEST( ArrayOfArraysTest, insertArray )
   {
     this->insertArray( 100, 10 );
   }
+}
+
+TYPED_TEST( ArrayOfArraysTest, copyConstruction )
+{
+  this->appendArray( 100, 10 );
+  ArrayOfArrays< TypeParam > a( this->m_array );
+
+  ASSERT_NE( &a( 0, 0 ), &this->m_array( 0, 0 ) );
+
+  COMPARE_TO_REFERENCE( this->m_array.toViewConst(), this->m_ref );
+  COMPARE_TO_REFERENCE( a.toViewConst(), this->m_ref );
+}
+
+TYPED_TEST( ArrayOfArraysTest, copyAssignment )
+{
+  this->appendArray( 100, 10 );
+  ArrayOfArrays< TypeParam > a;
+  ASSERT_EQ( a.size(), 0 );
+  a = this->m_array;
+
+  ASSERT_NE( &a( 0, 0 ), &this->m_array( 0, 0 ) );
+
+  COMPARE_TO_REFERENCE( this->m_array.toViewConst(), this->m_ref );
+  COMPARE_TO_REFERENCE( a.toViewConst(), this->m_ref );
+}
+
+TYPED_TEST( ArrayOfArraysTest, moveConstruction )
+{
+  this->appendArray( 100, 10 );
+  ArrayOfArrays< TypeParam > a( std::move( this->m_array ) );
+  ASSERT_EQ( this->m_array.size(), 0 );
+
+  COMPARE_TO_REFERENCE( a.toViewConst(), this->m_ref );
+}
+
+TYPED_TEST( ArrayOfArraysTest, moveAssignment )
+{
+  this->appendArray( 100, 10 );
+  ArrayOfArrays< TypeParam > a;
+  ASSERT_EQ( a.size(), 0 );
+  a = std::move( this->m_array );
+  ASSERT_EQ( this->m_array.size(), 0 );
+
+  COMPARE_TO_REFERENCE( a.toViewConst(), this->m_ref );
 }
 
 TYPED_TEST( ArrayOfArraysTest, eraseArray )


### PR DESCRIPTION
Closes #118 and removes unnecessary use of `CONSTEXPRFUNC`.